### PR TITLE
feat: Swagger, 공통 응답/예외 처리 및 User 도메인 초기 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,30 +1,45 @@
-# Compiled class file
-*.class
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
 
-# Log file
-*.log
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
 
-# BlueJ files
-*.ctxt
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
 
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-replay_pid*
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
 
 # VS Code #
 .vscode/
 
 # md file #
 HELP.md
+
+# 로컬 db 설정 파일
+application-local.yml
+
+._DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/solution/Ongi/OngiApplication.java
+++ b/src/main/java/com/solution/Ongi/OngiApplication.java
@@ -2,8 +2,10 @@ package com.solution.Ongi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class OngiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/solution/Ongi/domain/user/User.java
+++ b/src/main/java/com/solution/Ongi/domain/user/User.java
@@ -1,0 +1,51 @@
+package com.solution.Ongi.domain.user;
+
+import com.solution.Ongi.domain.user.enums.AlertInterval;
+import com.solution.Ongi.domain.user.enums.RelationType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Entity
+@Table(name="users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String loginId;
+
+    private String password;
+
+    private String guardianName;
+
+    private String guardianPhone;
+
+    private String seniorName;
+
+    private Integer seniorAge;
+
+    private String seniorPhone;
+
+    @Enumerated(EnumType.STRING)
+    private RelationType relation;
+
+    @Enumerated(EnumType.STRING)
+    private AlertInterval alertMax;
+
+
+}

--- a/src/main/java/com/solution/Ongi/domain/user/controller/UserController.java
+++ b/src/main/java/com/solution/Ongi/domain/user/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.solution.Ongi.domain.user.controller;
+
+import com.solution.Ongi.domain.user.dto.SignupRequest;
+import com.solution.Ongi.domain.user.User;
+import com.solution.Ongi.domain.user.service.UserService;
+import com.solution.Ongi.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user")
+public class UserController {
+    
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    @Operation(summary = "회원가입", description = """
+        "loginId": "hihi123",
+         "password": "1234",
+        "guardianName": "김보호",
+        "guardianPhoneNumber": "010-1234-5678",
+        "seniorName": "이어르신",
+        "seniorAge": 80,
+        "seniorPhone": "010-5678-1234",
+         "relation": "SON",
+         "alertMax": "MINUTES_30"
+    """)
+    // TODO: 추후 수정
+    public ResponseEntity<ApiResponse<User>> signup(@RequestBody SignupRequest request) {
+        User response = userService.signup(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+}

--- a/src/main/java/com/solution/Ongi/domain/user/dto/SignupRequest.java
+++ b/src/main/java/com/solution/Ongi/domain/user/dto/SignupRequest.java
@@ -1,0 +1,36 @@
+package com.solution.Ongi.domain.user.dto;
+
+import com.solution.Ongi.domain.user.enums.AlertInterval;
+import com.solution.Ongi.domain.user.enums.RelationType;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public record SignupRequest(
+    @NotNull
+    @NotEmpty
+    String loginId,
+    @NotNull
+    @NotEmpty
+    String password,
+    @NotNull
+    @NotEmpty
+    String guardianName,
+    @NotNull
+    @NotEmpty
+    String guardianPhone,
+    @NotNull
+    @NotEmpty
+    String seniorName,
+    @NotNull
+    @NotEmpty
+    Integer seniorAge,
+    @NotNull
+    @NotEmpty
+    String seniorPhone,
+    @NotNull
+    @NotEmpty
+    RelationType relation,
+    @NotNull
+    @NotEmpty
+    AlertInterval alertMax
+) { }

--- a/src/main/java/com/solution/Ongi/domain/user/enums/AlertInterval.java
+++ b/src/main/java/com/solution/Ongi/domain/user/enums/AlertInterval.java
@@ -1,0 +1,15 @@
+package com.solution.Ongi.domain.user.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum AlertInterval {
+    MINUTES_30(30),
+    MINUTES_60(60);
+
+    private final int value;
+
+    AlertInterval(int value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/solution/Ongi/domain/user/enums/RelationType.java
+++ b/src/main/java/com/solution/Ongi/domain/user/enums/RelationType.java
@@ -1,0 +1,5 @@
+package com.solution.Ongi.domain.user.enums;
+
+public enum RelationType {
+    SON, DAUGHTER, GRANDSON, GRANDDAUGHTER
+}

--- a/src/main/java/com/solution/Ongi/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/solution/Ongi/domain/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.solution.Ongi.domain.user.repository;
+
+import com.solution.Ongi.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByLoginId(String loginId);
+
+}

--- a/src/main/java/com/solution/Ongi/domain/user/service/UserService.java
+++ b/src/main/java/com/solution/Ongi/domain/user/service/UserService.java
@@ -1,0 +1,38 @@
+package com.solution.Ongi.domain.user.service;
+
+import com.solution.Ongi.domain.user.dto.SignupRequest;
+import com.solution.Ongi.domain.user.User;
+import com.solution.Ongi.domain.user.repository.UserRepository;
+import com.solution.Ongi.global.response.code.ErrorStatus;
+import com.solution.Ongi.global.response.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public User signup(SignupRequest request) {
+        if (userRepository.existsByLoginId(request.loginId())) {
+            throw new GeneralException(ErrorStatus.ERROR_STATUS);
+        }
+
+        User user = User.builder()
+            .loginId(request.loginId())
+            .password(request.password())
+            .guardianName(request.guardianName())
+            .guardianPhone(request.guardianPhone())
+            .seniorName(request.seniorName())
+            .seniorAge(request.seniorAge())
+            .seniorPhone(request.seniorPhone())
+            .relation(request.relation())
+            .alertMax(request.alertMax())
+            .build();
+
+        return userRepository.save(user);
+
+    }
+
+}

--- a/src/main/java/com/solution/Ongi/global/base/BaseTimeEntity.java
+++ b/src/main/java/com/solution/Ongi/global/base/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.solution.Ongi.global.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/solution/Ongi/global/config/SecurityConfig.java
+++ b/src/main/java/com/solution/Ongi/global/config/SecurityConfig.java
@@ -1,0 +1,33 @@
+package com.solution.Ongi.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable()) // POST 허용
+            .formLogin(formLogin -> formLogin.disable()) // 기본 로그인 비활성화
+            .httpBasic(httpBasic -> httpBasic.disable()) // http basic 비활성화
+            .authorizeHttpRequests(auth -> auth
+                // Swagger 경로는 인증 없이 허용
+                .requestMatchers(
+                    "/v3/api-docs/**",
+                    "/swagger-ui/**",
+                    "/swagger-ui.html",
+                    "/swagger-resources/**",
+                    "/webjars/**"
+                ).permitAll()
+                // 모든 요청 허용
+                .anyRequest().permitAll()
+            );
+
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/solution/Ongi/global/config/SwaggerConfig.java
+++ b/src/main/java/com/solution/Ongi/global/config/SwaggerConfig.java
@@ -1,0 +1,48 @@
+package com.solution.Ongi.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        // Define the security scheme
+        SecurityScheme apiKey = new SecurityScheme()
+            .type(Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT")
+
+            .in(SecurityScheme.In.HEADER)
+            .name("Authorization");
+
+        // Define the security requirement
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+            .addList("Authorization");
+
+        // Add the security scheme to components
+        Components components = new Components()
+            .addSecuritySchemes("Authorization", apiKey);
+
+        return new OpenAPI()
+            .addServersItem(new Server().url("/"))
+            .components(components)
+            .addSecurityItem(securityRequirement)
+            .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+            .title("Ongi API")
+            .description("Ongi Swagger입니다.")
+            .version("1.0.0");
+    }
+}

--- a/src/main/java/com/solution/Ongi/global/response/ApiResponse.java
+++ b/src/main/java/com/solution/Ongi/global/response/ApiResponse.java
@@ -1,0 +1,24 @@
+package com.solution.Ongi.global.response;
+
+import com.solution.Ongi.global.response.code.BaseCode;
+import com.solution.Ongi.global.response.code.SuccessStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private boolean success;
+    private int code;
+    private String message;
+    private T data;
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, SuccessStatus.SUCCESS.getCode(), SuccessStatus.SUCCESS.getMessage(), data);
+    }
+
+    public static ApiResponse<?> error (BaseCode code) {
+        return new ApiResponse<>(false, code.getHttpStatus().value(), code.getMessage(), null);
+    }
+
+}

--- a/src/main/java/com/solution/Ongi/global/response/code/BaseCode.java
+++ b/src/main/java/com/solution/Ongi/global/response/code/BaseCode.java
@@ -1,0 +1,9 @@
+package com.solution.Ongi.global.response.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseCode {
+    int getCode();
+    HttpStatus getHttpStatus();
+    String getMessage();
+}

--- a/src/main/java/com/solution/Ongi/global/response/code/ErrorStatus.java
+++ b/src/main/java/com/solution/Ongi/global/response/code/ErrorStatus.java
@@ -1,0 +1,18 @@
+package com.solution.Ongi.global.response.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseCode {
+
+    // 예시, 이후 필요한 에러코드 추가
+    ERROR_STATUS(400, HttpStatus.BAD_REQUEST, "Bad Request");
+
+    private final int code;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/src/main/java/com/solution/Ongi/global/response/code/SuccessStatus.java
+++ b/src/main/java/com/solution/Ongi/global/response/code/SuccessStatus.java
@@ -1,0 +1,17 @@
+package com.solution.Ongi.global.response.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode{
+    SUCCESS(200, HttpStatus.OK, "성공입니다.");
+
+    private final int code;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+
+}

--- a/src/main/java/com/solution/Ongi/global/response/exception/GeneralException.java
+++ b/src/main/java/com/solution/Ongi/global/response/exception/GeneralException.java
@@ -1,0 +1,17 @@
+package com.solution.Ongi.global.response.exception;
+
+import com.solution.Ongi.global.response.code.BaseCode;
+
+public class GeneralException extends RuntimeException {
+    private final BaseCode code;
+
+    public GeneralException(BaseCode code) {
+        super(code.getMessage());
+        this.code = code;
+    }
+
+    public BaseCode getCode() {
+        return code;
+    }
+
+}

--- a/src/main/java/com/solution/Ongi/global/response/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/solution/Ongi/global/response/exception/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package com.solution.Ongi.global.response.exception;
+
+import com.solution.Ongi.global.response.ApiResponse;
+import com.solution.Ongi.global.response.code.BaseCode;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ApiResponse<?>> handleGeneralException(GeneralException ex, HttpServletRequest request) {
+        if (request.getRequestURI().startsWith("/v3/api-docs")) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+        BaseCode code = ex.getCode();
+
+        return ResponseEntity
+            .status(code.getHttpStatus())
+            .body(ApiResponse.error(code));
+    }
+
+}

--- a/src/main/resources/application.YAML
+++ b/src/main/resources/application.YAML
@@ -1,0 +1,19 @@
+spring:
+  application:
+    name: ongi
+  config:
+    import: optional:application-local.yml
+  sql:
+    init:
+      platform: mysql
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: update
+    generate-ddl: true
+    show-sql: true
+    properties:
+      format_sql: true
+  logging:
+    level:
+      org.springframework.web: DEBUG


### PR DESCRIPTION
### 📌 작업 내용
- Swagger(OpenAPI 3.0) 설정 완료 (`SwaggerConfig`)
- 공통 응답/예외 처리 로직 구현 (`ApiResponse`, `GeneralException`, `GlobalExceptionHandler`)
- 사용자 회원가입 기능 초기 구현 -> 일단은 회원생성이 필요할 것 같아서 jwt없이 회원가입되도록 했고 추후에 수정하겠습니다

### 🧱 디렉토리 구조
- `domain/user` : User 관련 도메인, 서비스, 컨트롤러
- `global/response` : 공통 응답 포맷 및 에러코드 관리
- `global/config` : Swagger 및 Security 설정

### 📄 참고사항
- `application.yaml`에서 `application-local.yml` import 되도록 구성