### PR TITLE
feat: 문자 인증 및 회원가입 연동 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// CoolSMS
+	implementation 'net.nurigo:sdk:4.3.2'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/solution/Ongi/domain/smsverification/SmsVerification.java
+++ b/src/main/java/com/solution/Ongi/domain/smsverification/SmsVerification.java
@@ -1,0 +1,37 @@
+package com.solution.Ongi.domain.smsverification;
+
+import com.solution.Ongi.global.base.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+public class SmsVerification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String phoneNumber;
+
+    private String code;
+
+    @Default
+    private Boolean isVerified = false;
+
+    public void verify() {
+        this.isVerified = true;
+    }
+
+}

--- a/src/main/java/com/solution/Ongi/domain/smsverification/SmsVerificationController.java
+++ b/src/main/java/com/solution/Ongi/domain/smsverification/SmsVerificationController.java
@@ -1,0 +1,32 @@
+package com.solution.Ongi.domain.smsverification;
+
+import com.solution.Ongi.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/sms")
+public class SmsVerificationController {
+
+    private final SmsVerificationService smsVerificationService;
+
+    @PostMapping("/send-sms")
+    public ResponseEntity<ApiResponse<String>> sendCode(@RequestParam String phoneNumber) {
+        String response = smsVerificationService.sendVerificationCode(phoneNumber);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/verify-sms")
+    public ResponseEntity<ApiResponse<Boolean>> verifyCode(@RequestBody SmsVerifyRequest request) {
+        boolean isValid = smsVerificationService.verifyCode(request.phoneNumber(), request.code());
+        return ResponseEntity.ok(ApiResponse.success(isValid));
+    }
+
+
+}

--- a/src/main/java/com/solution/Ongi/domain/smsverification/SmsVerificationRepository.java
+++ b/src/main/java/com/solution/Ongi/domain/smsverification/SmsVerificationRepository.java
@@ -1,0 +1,11 @@
+package com.solution.Ongi.domain.smsverification;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SmsVerificationRepository extends JpaRepository<SmsVerification, Long> {
+    Optional<SmsVerification> findTopByPhoneNumberOrderByCreatedAtDesc(String phoneNumber);
+    void deleteByPhoneNumber(String phoneNumber);
+}

--- a/src/main/java/com/solution/Ongi/domain/smsverification/SmsVerificationService.java
+++ b/src/main/java/com/solution/Ongi/domain/smsverification/SmsVerificationService.java
@@ -18,7 +18,6 @@ public class SmsVerificationService {
 
     public String sendVerificationCode(String phoneNumber) {
         smsVerificationRepository.deleteByPhoneNumber(phoneNumber);
-
         String code = generateRandomCode();
 
         // 인증번호 저장
@@ -39,6 +38,10 @@ public class SmsVerificationService {
         SmsVerification verification = smsVerificationRepository
             .findTopByPhoneNumberOrderByCreatedAtDesc(phoneNumber)
             .orElseThrow(() -> new GeneralException(ErrorStatus.VERIFICATION_CODE_NOT_FOUND));
+
+        if (verification.getIsVerified()) {
+            throw new GeneralException(ErrorStatus.ALREADY_VERIFIED);
+        }
 
         if (verification.getCode().equals(inputCode)){
             verification.verify();

--- a/src/main/java/com/solution/Ongi/domain/smsverification/SmsVerificationService.java
+++ b/src/main/java/com/solution/Ongi/domain/smsverification/SmsVerificationService.java
@@ -1,0 +1,62 @@
+package com.solution.Ongi.domain.smsverification;
+
+import com.solution.Ongi.global.response.code.ErrorStatus;
+import com.solution.Ongi.global.response.exception.GeneralException;
+import com.solution.Ongi.global.util.SmsUtil;
+import jakarta.transaction.Transactional;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SmsVerificationService {
+
+    private final SmsVerificationRepository smsVerificationRepository;
+    private final SmsUtil smsUtil;
+
+    public String sendVerificationCode(String phoneNumber) {
+        smsVerificationRepository.deleteByPhoneNumber(phoneNumber);
+
+        String code = generateRandomCode();
+
+        // 인증번호 저장
+        SmsVerification verification = SmsVerification.builder()
+            .phoneNumber(phoneNumber)
+            .code(code)
+            .build();
+
+        smsVerificationRepository.save(verification);
+
+        // 인증번호 전송
+        smsUtil.sendOne(phoneNumber, code);
+
+        return "인증번호가 전송되었습니다.";
+    }
+
+    public boolean verifyCode(String phoneNumber, String inputCode) {
+        SmsVerification verification = smsVerificationRepository
+            .findTopByPhoneNumberOrderByCreatedAtDesc(phoneNumber)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.VERIFICATION_CODE_NOT_FOUND));
+
+        if (verification.getCode().equals(inputCode)){
+            verification.verify();
+            return true;
+        }
+
+        return false;
+    }
+
+
+    // 랜덤 4자리 발송
+    private String generateRandomCode() {
+        Random rand = new Random();
+        StringBuilder numStr = new StringBuilder();
+        for (int i = 0; i < 4; i++) {
+            numStr.append(rand.nextInt(10));
+        }
+        return numStr.toString();
+    }
+
+}

--- a/src/main/java/com/solution/Ongi/domain/smsverification/SmsVerifyRequest.java
+++ b/src/main/java/com/solution/Ongi/domain/smsverification/SmsVerifyRequest.java
@@ -1,0 +1,9 @@
+package com.solution.Ongi.domain.smsverification;
+
+
+public record SmsVerifyRequest(
+    String phoneNumber,
+    String code
+) {
+
+}

--- a/src/main/java/com/solution/Ongi/domain/user/controller/UserController.java
+++ b/src/main/java/com/solution/Ongi/domain/user/controller/UserController.java
@@ -27,10 +27,10 @@ public class UserController {
         "loginId": "hihi123",
          "password": "1234",
         "guardianName": "김보호",
-        "guardianPhoneNumber": "010-1234-5678",
+        "guardianPhoneNumber": "01012345678",
         "seniorName": "이어르신",
         "seniorAge": 80,
-        "seniorPhone": "010-5678-1234",
+        "seniorPhone": "01056781234",
          "relation": "SON",
          "alertMax": "MINUTES_30"
          "pushAgreement": true,

--- a/src/main/java/com/solution/Ongi/domain/user/service/UserService.java
+++ b/src/main/java/com/solution/Ongi/domain/user/service/UserService.java
@@ -1,11 +1,11 @@
 package com.solution.Ongi.domain.user.service;
 
 import com.solution.Ongi.domain.agreement.Agreement;
-import com.solution.Ongi.global.jwt.JwtTokenProvider;
 import com.solution.Ongi.domain.user.User;
 import com.solution.Ongi.domain.user.dto.LoginRequest;
 import com.solution.Ongi.domain.user.dto.SignupRequest;
 import com.solution.Ongi.domain.user.repository.UserRepository;
+import com.solution.Ongi.global.jwt.JwtTokenProvider;
 import com.solution.Ongi.global.response.code.ErrorStatus;
 import com.solution.Ongi.global.response.exception.GeneralException;
 import jakarta.transaction.Transactional;
@@ -68,4 +68,5 @@ public class UserService {
         boolean exists = userRepository.existsByLoginId(loginId);
         return exists ? "이미 사용 중인 아이디입니다." : "사용 가능한 아이디입니다.";
     }
+
 }

--- a/src/main/java/com/solution/Ongi/global/response/ApiResponse.java
+++ b/src/main/java/com/solution/Ongi/global/response/ApiResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ApiResponse<T> {
     private boolean success;
-    private int code;
+    private String code;
     private String message;
     private T data;
 
@@ -18,7 +18,7 @@ public class ApiResponse<T> {
     }
 
     public static ApiResponse<?> error (BaseCode code) {
-        return new ApiResponse<>(false, code.getHttpStatus().value(), code.getMessage(), null);
+        return new ApiResponse<>(false, code.getCode(), code.getMessage(), null);
     }
 
 }

--- a/src/main/java/com/solution/Ongi/global/response/code/BaseCode.java
+++ b/src/main/java/com/solution/Ongi/global/response/code/BaseCode.java
@@ -3,7 +3,7 @@ package com.solution.Ongi.global.response.code;
 import org.springframework.http.HttpStatus;
 
 public interface BaseCode {
-    int getCode();
+    String getCode();
     HttpStatus getHttpStatus();
     String getMessage();
 }

--- a/src/main/java/com/solution/Ongi/global/response/code/ErrorStatus.java
+++ b/src/main/java/com/solution/Ongi/global/response/code/ErrorStatus.java
@@ -15,6 +15,9 @@ public enum ErrorStatus implements BaseCode {
     USER_NOT_FOUND(400, HttpStatus.BAD_REQUEST, "존재 하지 않는 UserId입니다."),
     INVALID_PASSWORD(400, HttpStatus.BAD_REQUEST, "비밀번호가 유효하지 않습니다"),
 
+    // Sms
+    VERIFICATION_CODE_NOT_FOUND(400, HttpStatus.BAD_REQUEST, "올바르지 않은 인증번호입니다.")
+
 
     ;
 

--- a/src/main/java/com/solution/Ongi/global/response/code/ErrorStatus.java
+++ b/src/main/java/com/solution/Ongi/global/response/code/ErrorStatus.java
@@ -9,19 +9,22 @@ import org.springframework.http.HttpStatus;
 public enum ErrorStatus implements BaseCode {
 
     // 예시, 이후 필요한 에러코드 추가
-    ERROR_STATUS(400, HttpStatus.BAD_REQUEST, "Bad Request"),
+    ERROR_STATUS("COMMON400", HttpStatus.BAD_REQUEST, "Bad Request"),
 
     // User
-    USER_NOT_FOUND(400, HttpStatus.BAD_REQUEST, "존재 하지 않는 UserId입니다."),
-    INVALID_PASSWORD(400, HttpStatus.BAD_REQUEST, "비밀번호가 유효하지 않습니다"),
+    USER_NOT_FOUND("USER400", HttpStatus.BAD_REQUEST, "해당 UserId는 존재하지 않습니다."),
+    ALREADY_EXIST_USER("USER401", HttpStatus.BAD_REQUEST, "이미 존재하는 UserId입니다."),
+    INVALID_PASSWORD("USER402", HttpStatus.BAD_REQUEST, "비밀번호가 유효하지 않습니다"),
 
     // Sms
-    VERIFICATION_CODE_NOT_FOUND(400, HttpStatus.BAD_REQUEST, "올바르지 않은 인증번호입니다.")
+    VERIFICATION_CODE_NOT_FOUND("SMS400", HttpStatus.BAD_REQUEST, "해당 번호로 인증 요청이 없습니다."),
+    VERIFICATION_NOT_COMPLETED("SMS401", HttpStatus.BAD_REQUEST, "인증이 완료되지 않았습니다."),
+    ALREADY_VERIFIED("SMS402", HttpStatus.BAD_REQUEST, "이미 완료된 인증입니다."),
 
 
     ;
 
-    private final int code;
+    private final String code;
     private final HttpStatus httpStatus;
     private final String message;
 

--- a/src/main/java/com/solution/Ongi/global/response/code/SuccessStatus.java
+++ b/src/main/java/com/solution/Ongi/global/response/code/SuccessStatus.java
@@ -7,9 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum SuccessStatus implements BaseCode{
-    SUCCESS(200, HttpStatus.OK, "성공입니다.");
+    SUCCESS("COMMON200", HttpStatus.OK, "성공입니다.");
 
-    private final int code;
+    private final String code;
     private final HttpStatus httpStatus;
     private final String message;
 

--- a/src/main/java/com/solution/Ongi/global/util/SmsUtil.java
+++ b/src/main/java/com/solution/Ongi/global/util/SmsUtil.java
@@ -1,0 +1,40 @@
+package com.solution.Ongi.global.util;
+
+import jakarta.annotation.PostConstruct;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SmsUtil {
+
+    @Value("${coolsms.api.key}")
+    private String apiKey;
+    @Value("${coolsms.api.secret}")
+    private String apiSecretKey;
+    @Value("${coolsms.api.number}")
+    private String sendNumber;
+
+    private DefaultMessageService messageService;
+
+    @PostConstruct
+    private void init(){
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecretKey, "https://api.coolsms.co.kr");
+    }
+
+    // 단일 메시지 발송 예제
+    public SingleMessageSentResponse sendOne(String to, String verificationCode) {
+        Message message = new Message();
+        message.setFrom(sendNumber);
+        message.setTo(to);
+        message.setText("[ONGI] 아래의 인증번호를 입력해주세요\n" + verificationCode);
+
+        SingleMessageSentResponse response = this.messageService.sendOne(new SingleMessageSendingRequest(message));
+        return response;
+    }
+
+}


### PR DESCRIPTION
![IMG_9672](https://github.com/user-attachments/assets/3e2e0908-d37f-46f8-81fa-f3bb3dd7ab26)
## ✅ 변경 사항
 - SmsVerification 도메인 생성 및 인증 상태 저장
- 문자 인증 전송 기능 (/sms/send-sms) 구현
- 문자 인증 코드 검증 기능 (/sms/verify) 추가
- 회원가입 시 보호자 번호(guardianPhone) 인증 여부 검증 로직 추가
- 인증번호 응답 메시지 및 에러 코드 형식 수정
