### PR TITLE
feat: refreshToken 발급 및 LoginMode 처리 추가

### DIFF
--- a/src/main/java/com/solution/Ongi/domain/user/User.java
+++ b/src/main/java/com/solution/Ongi/domain/user/User.java
@@ -1,10 +1,13 @@
 package com.solution.Ongi.domain.user;
 
 import com.solution.Ongi.domain.agreement.Agreement;
+import com.solution.Ongi.domain.meal.Meal;
+import com.solution.Ongi.domain.medication.Medication;
 import com.solution.Ongi.domain.user.enums.AlertInterval;
 import com.solution.Ongi.domain.user.enums.RelationType;
 import com.solution.Ongi.global.base.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -13,20 +16,17 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import com.solution.Ongi.domain.meal.Meal;
-import com.solution.Ongi.domain.medication.Medication;
-import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -67,9 +67,7 @@ public class User extends BaseTimeEntity {
     @JoinColumn(name = "agreement_id")
     private Agreement agreement;
 
-    public void encodePassword(PasswordEncoder passwordEncoder) {
-        this.password = passwordEncoder.encode(this.password);
-    }
+    private String refreshToken;
 
     @Builder.Default
     @OneToMany(mappedBy = "user",cascade = CascadeType.ALL)
@@ -78,5 +76,14 @@ public class User extends BaseTimeEntity {
     @Builder.Default
     @OneToMany(mappedBy = "user",cascade = CascadeType.ALL)
     private List<Medication> medications=new ArrayList<>();
+
+
+    public void encodePassword(PasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(this.password);
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 
 }

--- a/src/main/java/com/solution/Ongi/domain/user/controller/UserController.java
+++ b/src/main/java/com/solution/Ongi/domain/user/controller/UserController.java
@@ -1,16 +1,19 @@
 package com.solution.Ongi.domain.user.controller;
 
-import com.solution.Ongi.domain.user.User;
 import com.solution.Ongi.domain.user.dto.LoginRequest;
 import com.solution.Ongi.domain.user.dto.SignupRequest;
+import com.solution.Ongi.domain.user.dto.SignupResponse;
+import com.solution.Ongi.domain.user.dto.LoginResponse;
 import com.solution.Ongi.domain.user.service.UserService;
 import com.solution.Ongi.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,20 +36,25 @@ public class UserController {
         "seniorPhone": "01056781234",
          "relation": "SON",
          "alertMax": "MINUTES_30"
-         "maxMissedResponses": 3,
+         "ignoreCnt": 3,
          "pushAgreement": true,
          "voiceAgreement": true,
          "backgroundAgreement": true
     """)
-    public ResponseEntity<ApiResponse<User>> signup(@RequestBody SignupRequest request) {
-        User user = userService.signup(request);
-        return ResponseEntity.ok(ApiResponse.success(user));
+    public ResponseEntity<ApiResponse<SignupResponse>> signup(@RequestBody SignupRequest request) {
+        SignupResponse response = userService.signup(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @PostMapping("/login")
-    @Operation(summary = "로그인", description = "발급된 토큰 이용 가능")
-    public ResponseEntity<ApiResponse<String>> login(@RequestBody LoginRequest request) {
-        String response = userService.login(request);
+    @Operation(summary = "로그인", description = """
+        로그인 시 보호자/어르신 모드를 선택해야 합니다. ("GUARDIAN" 또는 "SENIOR")
+        - 로그인 성공 시 accessToken과 refreshToken이 발급되며,
+          accessToken은 Authorization 헤더에 담아 API 호출 시 사용합니다.
+        - accessToken 유효기간은 1시간입니다.
+    """)
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody LoginRequest request) {
+        LoginResponse response = userService.login(request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -57,6 +65,14 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-
+    @PostMapping("/reissue")
+    @Operation(summary = "accessToken 재발급", description = "refreshToken을 헤더에 담아 전송하면 새로운 accessToken을 발급합니다.")
+    public ResponseEntity<ApiResponse<String>> reissue(@Parameter(hidden = true) @RequestHeader("Authorization") String refreshToken) {
+        if (refreshToken.startsWith("Bearer ")) {
+            refreshToken = refreshToken.substring(7);
+        }
+        String newAccessToken = userService.reissue(refreshToken);
+        return ResponseEntity.ok(ApiResponse.success(newAccessToken));
+    }
 
 }

--- a/src/main/java/com/solution/Ongi/domain/user/dto/LoginRequest.java
+++ b/src/main/java/com/solution/Ongi/domain/user/dto/LoginRequest.java
@@ -1,5 +1,6 @@
 package com.solution.Ongi.domain.user.dto;
 
+import com.solution.Ongi.domain.user.enums.LoginMode;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
@@ -7,7 +8,9 @@ public record LoginRequest(
     @NotNull @NotEmpty
     String id,
     @NotNull @NotEmpty
-    String password
+    String password,
+    @NotNull @NotEmpty
+    LoginMode mode
 ) {
 
 }

--- a/src/main/java/com/solution/Ongi/domain/user/dto/LoginResponse.java
+++ b/src/main/java/com/solution/Ongi/domain/user/dto/LoginResponse.java
@@ -1,0 +1,11 @@
+package com.solution.Ongi.domain.user.dto;
+
+import com.solution.Ongi.domain.user.enums.LoginMode;
+
+public record LoginResponse(
+    String accessToken,
+    String refreshToken,
+    LoginMode mode
+) {
+
+}

--- a/src/main/java/com/solution/Ongi/domain/user/dto/SignupResponse.java
+++ b/src/main/java/com/solution/Ongi/domain/user/dto/SignupResponse.java
@@ -1,0 +1,8 @@
+package com.solution.Ongi.domain.user.dto;
+
+public record SignupResponse(
+    Long userId,
+    String loginId
+) {
+
+}

--- a/src/main/java/com/solution/Ongi/domain/user/enums/LoginMode.java
+++ b/src/main/java/com/solution/Ongi/domain/user/enums/LoginMode.java
@@ -1,0 +1,5 @@
+package com.solution.Ongi.domain.user.enums;
+
+public enum LoginMode {
+    GUARDIAN, SENIOR
+}

--- a/src/main/java/com/solution/Ongi/global/config/AuthenticationConfig.java
+++ b/src/main/java/com/solution/Ongi/global/config/AuthenticationConfig.java
@@ -42,7 +42,7 @@ public class AuthenticationConfig {
                         "/swagger-resources/**",
                         "/webjars/**"
                     ).permitAll()
-                .requestMatchers("/user/login", "/user/signup").permitAll()
+                .requestMatchers("/user/login", "/user/signup", "/user/reissue", "/user/check-id").permitAll()
                 .requestMatchers(HttpMethod.POST, "/user/**").authenticated()
                 .anyRequest().permitAll()
             )

--- a/src/main/java/com/solution/Ongi/global/response/code/ErrorStatus.java
+++ b/src/main/java/com/solution/Ongi/global/response/code/ErrorStatus.java
@@ -18,6 +18,9 @@ public enum ErrorStatus implements BaseCode {
 
     // Auth
     UNAUTHORIZED_ACCESS("AUTH400", HttpStatus.FORBIDDEN, "해당 리소스에 접근할 권한이 없습니다."),
+    INVALID_TOKEN("AUTH401", HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
+    TOKEN_MISMATCH("AUTH402", HttpStatus.BAD_REQUEST, "일치하지 않는 토큰입니다"),
+
 
 
     // Sms


### PR DESCRIPTION
## ✅ 변경 사항
	
- 로그인 시 accessToken과 refreshToken 동시 발급
  - accessToken: 1시간 유효
  - refreshToken: 14일 유효, DB에 저장
- /user/reissue 추가
  - 헤더에 refreshToken을 담아 accessToken 재발급 요청 가능
- 로그인 시 보호자/노약자 모드 선택