### PR TITLE
feat: 보호자모드로 최초 로그인시 개인정보 약관 동의 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 //	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 
@@ -49,7 +48,6 @@ dependencies {
 	implementation 'com.google.firebase:firebase-admin:9.4.3'
 
 	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-//	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
@@ -51,6 +51,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/solution/Ongi/domain/agreement/Agreement.java
+++ b/src/main/java/com/solution/Ongi/domain/agreement/Agreement.java
@@ -33,6 +33,10 @@ public class Agreement extends BaseTimeEntity {
     @Builder.Default
     private Boolean personalInfoAgreement = false;
 
+    public void markPersonalInfoAgreement() {
+        this.personalInfoAgreement = true;
+    }
+
 
 
 }

--- a/src/main/java/com/solution/Ongi/domain/user/controller/UserController.java
+++ b/src/main/java/com/solution/Ongi/domain/user/controller/UserController.java
@@ -4,13 +4,17 @@ import com.solution.Ongi.domain.user.dto.LoginRequest;
 import com.solution.Ongi.domain.user.dto.LoginResponse;
 import com.solution.Ongi.domain.user.dto.SignupRequest;
 import com.solution.Ongi.domain.user.dto.SignupResponse;
+import com.solution.Ongi.domain.user.dto.UserInfoResponse;
 import com.solution.Ongi.domain.user.service.UserService;
+import com.solution.Ongi.global.jwt.JwtTokenProvider;
 import com.solution.Ongi.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
     
     private final UserService userService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/signup")
     @Operation(summary = "회원가입", description = """
@@ -74,6 +79,32 @@ public class UserController {
         }
         String newAccessToken = userService.reissue(refreshToken);
         return ResponseEntity.ok(ApiResponse.success(newAccessToken));
+    }
+
+    @GetMapping("/me")
+    @Operation(
+        summary = "유저 정보 조회",
+        description = """
+        현재 로그인한 사용자의 정보를 반환합니다. <br><br>
+        - 보호자 모드로 로그인할 시 개인정보 동의 여부(`personalInfoAgreement`) null로 반환,
+         노약자 모드로 로그인 시 개인정보 동의 여부(`personalInfoAgreement`) boolean값으로 반환<br>
+        """
+    )
+    public ResponseEntity<ApiResponse<UserInfoResponse>> getMyProfile(
+        Authentication authentication,
+        HttpServletRequest request) {
+        String token = request.getHeader("Authorization").substring(7);
+        String loginId = authentication.getName();
+
+        UserInfoResponse response = userService.getUserInfoWithMode(token, loginId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/guardian-agreement")
+    @Operation(summary = "보호자 최초 로그인시 개인정보 약관 동의")
+    public ResponseEntity<ApiResponse<String>> agreeGuardianTerms(Authentication authentication) {
+        userService.markGuardianAgreement(authentication.getName());
+        return ResponseEntity.ok(ApiResponse.success("약관에 동의하였습니다."));
     }
 
 }

--- a/src/main/java/com/solution/Ongi/domain/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/solution/Ongi/domain/user/dto/UserInfoResponse.java
@@ -1,0 +1,21 @@
+package com.solution.Ongi.domain.user.dto;
+
+import com.solution.Ongi.domain.user.User;
+import com.solution.Ongi.domain.user.enums.LoginMode;
+
+public record UserInfoResponse(
+    Long id,
+    String loginId,
+    Boolean isSenior,
+    Boolean personalInfoAgreement
+) {
+    public static UserInfoResponse from(User user, LoginMode mode) {
+        return new UserInfoResponse(
+            user.getId(),
+            user.getLoginId(),
+            mode == LoginMode.SENIOR,
+            mode == LoginMode.SENIOR ? user.getAgreement().getPersonalInfoAgreement() : null
+        );
+    }
+
+}

--- a/src/main/java/com/solution/Ongi/domain/user/service/UserService.java
+++ b/src/main/java/com/solution/Ongi/domain/user/service/UserService.java
@@ -8,6 +8,8 @@ import com.solution.Ongi.domain.user.dto.LoginRequest;
 import com.solution.Ongi.domain.user.dto.LoginResponse;
 import com.solution.Ongi.domain.user.dto.SignupRequest;
 import com.solution.Ongi.domain.user.dto.SignupResponse;
+import com.solution.Ongi.domain.user.dto.UserInfoResponse;
+import com.solution.Ongi.domain.user.enums.LoginMode;
 import com.solution.Ongi.domain.user.repository.UserRepository;
 import com.solution.Ongi.global.jwt.JwtTokenProvider;
 import com.solution.Ongi.global.response.code.ErrorStatus;
@@ -19,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-//@Transactional(readOnly = true)
 @Transactional
 public class UserService {
 
@@ -78,7 +79,7 @@ public class UserService {
             throw new GeneralException(ErrorStatus.INVALID_PASSWORD);
         }
 
-        String accessToken = jwtProvider.createToken(user.getLoginId());
+        String accessToken = jwtProvider.createToken(user.getLoginId(), request.mode().name());
         String refreshToken = jwtProvider.createRefreshToken(user.getLoginId());
 
         user.updateRefreshToken(refreshToken);
@@ -94,6 +95,8 @@ public class UserService {
         }
 
         String loginId = jwtProvider.getLoginIdFromToken(refreshToken);
+        String mode = jwtProvider.getModeFromToken(refreshToken);
+
         User user = userRepository.findByLoginId(loginId)
             .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
@@ -101,7 +104,18 @@ public class UserService {
             throw new GeneralException(ErrorStatus.TOKEN_MISMATCH);
         }
 
-        return jwtProvider.createToken(user.getLoginId());
+        return jwtProvider.createToken(user.getLoginId(), mode);
+    }
+
+    public UserInfoResponse getUserInfoWithMode(String token, String loginId) {
+        LoginMode mode = LoginMode.valueOf(jwtProvider.getModeFromToken(token));
+        User user = getUserByLoginIdOrThrow(loginId);
+        return UserInfoResponse.from(user, mode);
+    }
+
+    public void markGuardianAgreement(String loginId) {
+        User user = getUserByLoginIdOrThrow(loginId);
+        user.getAgreement().markPersonalInfoAgreement();
     }
 
     public String isDuplicatedId(String loginId) {

--- a/src/main/java/com/solution/Ongi/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/solution/Ongi/global/jwt/JwtTokenProvider.java
@@ -24,13 +24,14 @@ public class JwtTokenProvider {
     }
 
     // 토큰 생성 메서드
-    public String createToken(String loginId) {
+    public String createToken(String loginId, String mode) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + expiration);
 
         return Jwts.builder()
             .setSubject(loginId)
             .claim("type", "access")
+            .claim("mode", mode)
             .setIssuedAt(now)
             .setExpiration(expiryDate)
             .signWith(key, SignatureAlgorithm.HS256)
@@ -76,5 +77,9 @@ public class JwtTokenProvider {
             .build()
             .parseClaimsJws(token)
             .getBody();
+    }
+
+    public String getModeFromToken(String token) {
+        return getClaims(token).get("mode", String.class);
     }
 }


### PR DESCRIPTION
## ✅ 변경 사항
- 로그인 시 JWT에 로그인모드(GUARDIAN 또는 SENIOR)를 포함하여 발급되도록 수정
- 보호자(Guardian) 모드 최초 로그인 시 개인정보 수집 및 이용 동의 여부 확인 기능 추가
- /me 유저 조회 API에서 로그인 모드에 따라 약관 동의 여부 반환 